### PR TITLE
fixed cloud bottom row not working

### DIFF
--- a/_sass/_09_elements.scss
+++ b/_sass/_09_elements.scss
@@ -250,6 +250,7 @@ img.lazy {
 ------------------------------------------------------------------- */
 
 .tagcloud03 {
+    margin-bottom: 75px;
     ul.cloud {
         li {
             // height: inherit;


### PR DESCRIPTION
added margin bottom to tag cloud in order for the bottom row to link due to the extra margin to get the anchor tag placement right