### PR TITLE
Fix render-link.html path

### DIFF
--- a/content/posts/2022/022522-hugo-link-other-pages.md
+++ b/content/posts/2022/022522-hugo-link-other-pages.md
@@ -18,7 +18,7 @@ In the render-link.html, we need to look at the prefix of the `.Destination` to 
 Copy this code snippet into the render-link.html.
 
 ```text
-<a href=“{{ .Destination | safeURL }}”{{ with .Title}} title=“{{ . }}”{{ end }}{{ if or (strings.HasPrefix .Destination “http”) (strings.HasPrefix .Destination “https”) }} target=“_blank”{{ end }} >{{ .Text | safeHTML }}</a>
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if or (strings.HasPrefix .Destination "http") (strings.HasPrefix .Destination "https") }} target="_blank"{{ end }} >{{ .Text | safeHTML }}</a>
 ```
 
 Now when any link starts with http or https, it will open in a new tab while links within the website will open in the same tab

--- a/content/posts/2022/022522-hugo-link-other-pages.md
+++ b/content/posts/2022/022522-hugo-link-other-pages.md
@@ -11,7 +11,7 @@ For Hugo based websites, when a link goes to an external website, I prefer to ha
 
 <!--more-->
 
-To accomplish the goal of opening all external links in a new tab, you need to override the Hugo default behavior for rendering links by creating the file layouts\_defaults\_markup\render-link.html.
+To accomplish the goal of opening all external links in a new tab, you need to override the Hugo default behavior for rendering links by creating the file `layouts/_defaults/_markup/render-link.html`.
 
 In the render-link.html, we need to look at the prefix of the `.Destination` to see if it starts with http or https and if it does then add the `target="_blank"
 


### PR DESCRIPTION
Hi there!

I was looking for how to do this :eyes: And i found your guide, thanks!!!

But I see the windoza-style slashes cancelled-out... and they look like this:
![image](https://user-images.githubusercontent.com/40139196/192489284-d27f607d-d1c7-4db2-bb37-13d06e1a4e92.png)

I propose to change them to unix/web-style slashes + \` to be sure :+1:

Cheers!